### PR TITLE
Modify pages to use brutalism style for all content layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -145,11 +145,10 @@
         padding-left: 48px;
         z-index: 0;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
         height: auto;
         min-height: 100%;
-        background-image: url('https://www.transparenttextures.com/patterns/concrete-wall.png');
       }
 
       .header {
@@ -157,12 +156,12 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding-top: 16px;
-        padding-bottom: 16px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 3;
         background-color: #ffffff;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .logo {
@@ -190,6 +189,8 @@
         gap: 32px;
         flex-shrink: 0;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .nav-link {
@@ -256,8 +257,8 @@
         flex-shrink: 0;
         align-self: stretch;
         font-size: 120px;
-        font-family: DotGothic16;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 180px;
         letter-spacing: -0.02em;
         color: #000000;
@@ -272,8 +273,8 @@
         align-self: stretch;
         text-align: center;
         font-size: 24px;
-        font-family: Archivo;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 32px;
         letter-spacing: -0.005em;
         color: #000000;
@@ -289,15 +290,15 @@
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        padding-top: 96px;
-        padding-bottom: 24px;
         gap: 24px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 1;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .footer-content {

--- a/contact.html
+++ b/contact.html
@@ -145,11 +145,10 @@
         padding-left: 48px;
         z-index: 0;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
         height: auto;
         min-height: 100%;
-        background-image: url('https://www.transparenttextures.com/patterns/concrete-wall.png');
       }
 
       .header {
@@ -157,12 +156,12 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding-top: 16px;
-        padding-bottom: 16px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 3;
         background-color: #ffffff;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .logo {
@@ -190,6 +189,8 @@
         gap: 32px;
         flex-shrink: 0;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .nav-link {
@@ -256,8 +257,8 @@
         flex-shrink: 0;
         align-self: stretch;
         font-size: 120px;
-        font-family: DotGothic16;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 180px;
         letter-spacing: -0.02em;
         color: #000000;
@@ -272,8 +273,8 @@
         align-self: stretch;
         text-align: center;
         font-size: 24px;
-        font-family: Archivo;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 32px;
         letter-spacing: -0.005em;
         color: #000000;
@@ -377,15 +378,15 @@
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        padding-top: 96px;
-        padding-bottom: 24px;
         gap: 24px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 1;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .footer-content {

--- a/index.html
+++ b/index.html
@@ -147,11 +147,10 @@
         padding-left: 48px;
         z-index: 0;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
         height: auto;
         min-height: 100%;
-        background-image: url('https://www.transparenttextures.com/patterns/concrete-wall.png');
       }
 
       .header {
@@ -159,12 +158,12 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding-top: 16px;
-        padding-bottom: 16px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 3;
         background-color: #ffffff;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .logo {
@@ -192,6 +191,8 @@
         gap: 32px;
         flex-shrink: 0;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .nav-link {
@@ -258,8 +259,8 @@
         flex-shrink: 0;
         align-self: stretch;
         font-size: 120px;
-        font-family: DotGothic16;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 180px;
         letter-spacing: -0.02em;
         color: #000000;
@@ -274,8 +275,8 @@
         align-self: stretch;
         text-align: center;
         font-size: 120px;
-        font-family: DotGothic16;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 180px;
         letter-spacing: -0.02em;
         color: #000000;
@@ -691,15 +692,15 @@
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        padding-top: 96px;
-        padding-bottom: 24px;
         gap: 24px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 1;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .footer-content {

--- a/projects.html
+++ b/projects.html
@@ -145,11 +145,10 @@
         padding-left: 48px;
         z-index: 0;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
         height: auto;
         min-height: 100%;
-        background-image: url('https://www.transparenttextures.com/patterns/concrete-wall.png');
       }
 
       .header {
@@ -157,12 +156,12 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding-top: 16px;
-        padding-bottom: 16px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 3;
         background-color: #ffffff;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .logo {
@@ -190,6 +189,8 @@
         gap: 32px;
         flex-shrink: 0;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .nav-link {
@@ -256,8 +257,8 @@
         flex-shrink: 0;
         align-self: stretch;
         font-size: 120px;
-        font-family: DotGothic16;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 180px;
         letter-spacing: -0.02em;
         color: #000000;
@@ -272,8 +273,8 @@
         align-self: stretch;
         text-align: center;
         font-size: 24px;
-        font-family: Archivo;
-        font-weight: 400;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
         line-height: 32px;
         letter-spacing: -0.005em;
         color: #000000;
@@ -289,15 +290,15 @@
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        padding-top: 96px;
-        padding-bottom: 24px;
         gap: 24px;
         flex-shrink: 0;
         align-self: stretch;
         z-index: 1;
         overflow: hidden;
-        background-color: #ffffff;
+        background-color: #f2f2f2;
         position: relative;
+        font-family: 'Courier New', Courier, monospace;
+        font-weight: bold;
       }
 
       .footer-content {


### PR DESCRIPTION
Modify the layout of `index.html`, `about.html`, `contact.html`, and `projects.html` to follow the brutalism style.

* **Background Color and Image**:
  - Change the background color of the `.container` class to `#f2f2f2` and remove the background image in all files.

* **Header**:
  - Update the `.header` class to use a bold, unpolished font (`'Courier New', Courier, monospace`) and remove padding in all files.

* **Navigation Links**:
  - Update the `.nav-links` class to use a raw, unpolished appearance with the same font and bold style in all files.

* **Titles and Text**:
  - Modify the `.intro-title`, `.intro-subtitle`, `.about-title`, `.about-text`, `.contact-title`, `.contact-info`, `.projects-title`, and `.projects-list` classes to use the bold, unpolished font in all files.

* **Footer**:
  - Change the background color of the `.footer` class to `#f2f2f2`, remove padding, and update the font to the bold, unpolished style in all files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muhammad-shalahuddin-amrullah/Bold-Landing-Page/pull/6?shareId=c3094488-ce28-4333-aa80-31c4cefe75a7).